### PR TITLE
Fix tunnel initialization issues

### DIFF
--- a/src/tunnelgraf/tunnel_builder.py
+++ b/src/tunnelgraf/tunnel_builder.py
@@ -26,24 +26,27 @@ class TunnelBuilder:
             raise ValueError(
                 "TunnelDefinition must have a nexthop when creating a tunnel."
             )
+        self.tunnel_kwargs: dict = {}
         if self.tunnel_config.proxycommand is not None:
             self.tunnel_kwargs["ssh_proxy"] = paramiko.ProxyCommand(
                 self.tunnel_config.proxycommand
             )
         if self.tunnel_config.nexthop.hostlookup:
             self.tunnel_config.nexthop.host = self._lookup_host(self.tunnel_config)
-        self.tunnel_kwargs: dict = {
-            "compression": True,
-            "ssh_username": self.tunnel_config.sshuser,
-            "remote_bind_address": (
-                self.tunnel_config.nexthop.host,
-                self.tunnel_config.nexthop.port,
-            ),
-            "local_bind_address": (
-                self.tunnel_config.nexthop.localbindaddress,
-                self.tunnel_config.nexthop.localbindport,
-            ),
-        }
+        self.tunnel_kwargs.update(
+            {
+                "compression": True,
+                "ssh_username": self.tunnel_config.sshuser,
+                "remote_bind_address": (
+                    self.tunnel_config.nexthop.host,
+                    self.tunnel_config.nexthop.port,
+                ),
+                "local_bind_address": (
+                    self.tunnel_config.nexthop.localbindaddress,
+                    self.tunnel_config.nexthop.localbindport,
+                ),
+            }
+        )
         if self.tunnel_config.sshkeyfile is not None:
             logger.debug("sshkeyfile present, using it instead of password.")
             self.tunnel_kwargs["ssh_pkey"] = self.tunnel_config.sshkeyfile

--- a/src/tunnelgraf/tunnels.py
+++ b/src/tunnelgraf/tunnels.py
@@ -161,7 +161,7 @@ class Tunnels:
     @config_file.setter
     def config_file(self, cf: str):
         """Sets the config file."""
-        if not cf or isinstance(cf, str):
+        if not cf or not isinstance(cf, str):
             raise ValueError("Config file must not be blank.")
         if not os.path.isfile(cf):
             raise ValueError(f"Config file {cf} does not exist.")


### PR DESCRIPTION
## Summary
- avoid using `self.tunnel_kwargs` before it exists in `TunnelBuilder`
- correct `Tunnels.config_file` validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_688762621674832585f4669a16fdfbe4